### PR TITLE
Fix crash when creating first-ever Task

### DIFF
--- a/calcure/data.py
+++ b/calcure/data.py
@@ -297,6 +297,8 @@ class Tasks(Collection):
 
     def generate_id(self):
         """Generate a id for a new item. The id is generated as maximum of existing ids plus one"""
+        if self.is_empty():
+            return 0
         return max([item.item_id for item in self.items]) + 1
 
 


### PR DESCRIPTION
Previously, when there were no Tasks and `Tasks.generate_id` was called, the `max` function would throw a ValueError.

Now we check to see if the Task list is empty before generating a new ID. If empty, then the generated ID will always be 0.

Resolves #23 